### PR TITLE
Bugfix: Getting non direct attribute name

### DIFF
--- a/esm/walker.js
+++ b/esm/walker.js
@@ -91,21 +91,15 @@ function parseAttributes(node, holes, parts, path) {
       // and the IE9 double viewBox test
       /* istanbul ignore else */
       if (!cache.has(name)) {
-        var realName = parts.shift().replace(
-          direct ?
-            /^(?:|[\S\s]*?\s)(\S+?)\s*=\s*('|")?$/ :
-            // TODO: while working on yet another IE/Edge bug I've realized
-            //        the current not direct logic easily breaks there
-            //        because the `name` might not be the real needed one.
-            //        Use a better RegExp to find last attribute instead
-            //        of trusting `name` is what we are looking for.
-            //        Thanks IE/Edge, I hate you both.
-            new RegExp(
-              '^(?:|[\\S\\s]*?\\s)(' + name + ')\\s*=\\s*(\'|")',
-              'i'
-            ),
-            '$1'
-        );
+        var realName;
+        if (direct) {
+          realName = parts.shift().replace(/^(?:|[\S\s]*?\s)(\S+?)\s*=\s*('|")?$/, '$1');
+        } else {
+          // TODO: improve current regex so that we don't need to use "replace" 3 times...
+          var part = parts.shift();
+          var regex = new RegExp(`^(?:|[\\S\\s]*?\\s)(${name})\\s*=\\s*('|")`, 'i');
+          realName = part.replace(regex, '$1').replace(part.replace(regex, '$2').slice(1), '');
+        }
         var value = attributes[realName] ||
                       // the following ignore is covered by browsers
                       // while basicHTML is already case-sensitive

--- a/esm/walker.js
+++ b/esm/walker.js
@@ -78,7 +78,11 @@ function parseAttributes(node, holes, parts, path) {
   var cache = new Map;
   var attributes = node.attributes;
   var remove = [];
-  var array = remove.slice.call(attributes, 0);
+  var html = parts.join('');
+  // This is a fix for returning an ordered list of attributes (IE and Edge don't)
+  var array = remove.slice.call(attributes, 0).sort(function(left, right) {
+    return html.indexOf(left.name) <= html.indexOf(right.name) ? -1 : 1;
+  });
   var length = array.length;
   var i = 0;
   while (i < length) {


### PR DESCRIPTION
This PR fixes the bug on lighterhtml of matching the attribute name correctly when interpolated values are introduced.

Example of code that does not work before the fix:
```javascript
html`<div class="block__element${hasModifier ? '--modifier' : ''}"></div>`;
```

Implementation of attribute re-ordering is based on the fact that all "attributes" exist in the parent node, so "indexOf" will not return indices from other nodes (children for example).

Discussion started here:
https://github.com/WebReflection/lighterhtml/pull/66